### PR TITLE
BUG: Bypass import read_strava to solve a readthedocs fix

### DIFF
--- a/runpandas/__init__.py
+++ b/runpandas/__init__.py
@@ -1,6 +1,10 @@
 from runpandas.reader import _read_file as read_file  # noqa
 from runpandas.reader import _read_dir as read_dir  # noqa
-from runpandas.io.strava._parser import read_strava  # noqa
+
+try:
+    from runpandas.io.strava._parser import read_strava  # noqa
+except Exception:
+    pass  # it is a bypass for readthedocs build. to solve!
 
 from ._version import get_versions
 


### PR DESCRIPTION
Import error 

`Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/runpandas/conda/latest/lib/python3.8/site-packages/sphinx/config.py", line 326, in eval_config_file
    execfile_(filename, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/runpandas/conda/latest/lib/python3.8/site-packages/sphinx/util/pycompat.py", line 88, in execfile_
    exec(code, _globals)
  File "/home/docs/checkouts/readthedocs.org/user_builds/runpandas/checkouts/latest/docs/source/conf.py", line 16, in <module>
    import runpandas as rp
  File "/home/docs/checkouts/readthedocs.org/user_builds/runpandas/conda/latest/lib/python3.8/site-packages/runpandas/__init__.py", line 3, in <module>
    from runpandas.io.strava._parser import read_strava  # noqa
ModuleNotFoundError: No module named 'runpandas.io.strava'
`