### PR TITLE
BUG: Fix setup.py import fix (findpackages)

### DIFF
--- a/docs/source/_version.txt
+++ b/docs/source/_version.txt
@@ -1,1 +1,1 @@
-Version: **0.1 (+31, 0774f25)** Date: **January 11, 2021**
+Version: **0.1 (+33, 9999389)** Date: **January 12, 2021**

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,6 @@ setup(
     python_requires=">=3.6",
     include_package_data=True,
     install_requires=INSTALL_REQUIRES,
-    packages=["runpandas", "runpandas.io", "runpandas.types"],
+    packages=find_packages(exclude=['tests*']),
     zip_safe=False,
 )


### PR DESCRIPTION
It fixes the problem of 
`python setup.py dist` with modulenotfound errors while importing runpandas.

See #31 .