### PR TITLE
BLD: Fixes on Docs environment build process.

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - nbformat
 - jupyter_client
 - ipykernel
-- sphinx
+- sphinx==4.4.0
 - terminado
 - pip:
   - nbsphinx

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,11 +1,11 @@
-sphinx
+sphinx==4.4.0
 ipython
 sphinx_rtd_theme
 requests_cache
-pydata_sphinx_theme
+pydata_sphinx_theme==0.9.0
 ipykernel
-nbsphinx
-sphinxcontrib_github_alt
-commonmark
-recommonmark
+nbsphinx==0.8.9
+sphinxcontrib_github_alt==1.2
+commonmark==0.9.1
+recommonmark==0.7.1
 

--- a/docs/source/_version.txt
+++ b/docs/source/_version.txt
@@ -1,1 +1,1 @@
-Version: **0.5.1 (+38, b313d25)** Date: **July 29, 2022**
+Version: **0.5.2 (+0, 27c3793)** Date: **August 4, 2022**

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,7 +48,7 @@ source_parsers = {
     ".md": "recommonmark.parser.CommonMarkParser",
 }
 
-source_suffix = [".rst", ".md", ".ipynb"]
+source_suffix = [".rst", ".md"]  # #".ipynb"]
 master_doc = "index"
 
 github_project_url = "https://github.com/corriporai/runpandas"


### PR DESCRIPTION
- Fixes on requirements for Sphinx ReadTheDocs build process. The Sphinx version 5.0.1 didn't find some runpandas packages due to import problems. To investigate. For now , we will fix the version 4.4.4 for Sphinx.

`
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/runpandas/conda/latest/lib/python3.8/site-packages/sphinx/ext/autosummary/generate.py", line 394, in generate_autosummary_docs
    name, obj, parent, modname = import_by_name(entry.name)
  File "/home/docs/checkouts/readthedocs.org/user_builds/runpandas/conda/latest/lib/python3.8/site-packages/sphinx/ext/autosummary/__init__.py", line 654, in import_by_name
    raise ImportExceptionGroup('no module named %s' % ' or '.join(tried), exceptions)
sphinx.ext.autosummary.ImportExceptionGroup: no module named runpandas._testing.skip_on_exception

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/runpandas/conda/latest/lib/python3.8/site-packages/sphinx/events.py", line 94, in emit
    results.append(listener.handler(self.app, *args))
  File "/home/docs/checkouts/readthedocs.org/user_builds/runpandas/conda/latest/lib/python3.8/site-packages/sphinx/ext/autosummary/__init__.py", line 804, in process_generate_options
    generate_autosummary_docs(genfiles, suffix=suffix, base_path=app.srcdir,
  File "/home/docs/checkouts/readthedocs.org/user_builds/runpandas/conda/latest/lib/python3.8/site-packages/sphinx/ext/autosummary/generate.py", line 399, in generate_autosummary_docs
    name, obj, parent, modname = import_ivar_by_name(entry.name)
  File "/home/docs/checkouts/readthedocs.org/user_builds/runpandas/conda/latest/lib/python3.8/site-packages/sphinx/ext/autosummary/__init__.py", line 713, in import_ivar_by_name
    real_name, obj, parent, modname = import_by_name(name, prefixes, grouped_exception)
  File "/home/docs/checkouts/readthedocs.org/user_builds/runpandas/conda/latest/lib/python3.8/site-packages/sphinx/ext/autosummary/__init__.py", line 654, in import_by_name
    raise ImportExceptionGroup('no module named %s' % ' or '.join(tried), exceptions)
sphinx.ext.autosummary.ImportExceptionGroup: no module named runpandas._testing

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/runpandas/conda/latest/lib/python3.8/site-packages/sphinx/cmd/build.py", line 272, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
  File "/home/docs/checkouts/readthedocs.org/user_builds/runpandas/conda/latest/lib/python3.8/site-packages/sphinx/application.py", line 256, in __init__
    self._init_builder()
  File "/home/docs/checkouts/readthedocs.org/user_builds/runpandas/conda/latest/lib/python3.8/site-packages/sphinx/application.py", line 314, in _init_builder
    self.events.emit('builder-inited')
  File "/home/docs/checkouts/readthedocs.org/user_builds/runpandas/conda/latest/lib/python3.8/site-packages/sphinx/events.py", line 102, in emit
    raise ExtensionError(__("Handler %r for event %r threw an exception") %
sphinx.errors.ExtensionError: Handler <function process_generate_options at 0x7fa3afa72d30> for event 'builder-inited' threw an exception (exception: no module named runpandas._testing)

Extension error (sphinx.ext.autosummary):
Handler <function process_generate_options at 0x7fa3afa72d30> for event 'builder-inited' threw an exception (exception: no module named runpandas._testing)
`